### PR TITLE
third_part

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -22,10 +22,18 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    if Interview.update(params[:id], update_params)
-      redirect_to user_interviews_path, notice: '日程情報を修正しました'
-    else
-      redirect_to user_interviews_path, alert: '失敗しました。やり直して下さい'
+    if current_user.id == params[:user_id].to_i     # 自分の面接日程を編集する場合
+      if Interview.update(params[:id], update_params)
+        redirect_to user_interviews_path, notice: '日程情報を修正しました'
+      else
+        redirect_to user_interviews_path, alert: '失敗しました。やり直して下さい'
+      end
+    else                                            # 他人の面接日程を承認する場合
+      if Interview.where(id: params[:id]).update(state: 1)
+        redirect_to user_interviews_path, notice: '面接日程を確定しました'
+      else
+        redirect_to user_interviews_path, alert: '日程確定に失敗しました'
+      end
     end
   end
 
@@ -34,14 +42,6 @@ class InterviewsController < ApplicationController
       redirect_to user_interviews_path, notice: '日程を削除しました'
     else
       redirect_to user_interviews_path, alert: '失敗しました。やり直して下さい'
-    end
-  end
-
-  def change_state
-    if Interview.where(id: params[:id]).update(state: 1)
-      redirect_to user_interviews_path, notice: '面接日程を確定しました'
-    else
-      redirect_to user_interviews_path, alert: '日程確定に失敗しました'
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,6 +2,7 @@ class InterviewsController < ApplicationController
 
   def index
     @interviews = Interview.where(user_id: params[:user_id]).order(interview_datetime: :asc)
+    @user       = User.find(params[:user_id])
   end
 
   def new
@@ -33,6 +34,14 @@ class InterviewsController < ApplicationController
       redirect_to user_interviews_path, notice: '日程を削除しました'
     else
       redirect_to user_interviews_path, alert: '失敗しました。やり直して下さい'
+    end
+  end
+
+  def change_state
+    if Interview.where(id: params[:id]).update(state: 1)
+      redirect_to user_interviews_path, notice: '面接日程を確定しました'
+    else
+      redirect_to user_interviews_path, alert: '日程確定に失敗しました'
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,7 +1,7 @@
 class InterviewsController < ApplicationController
 
   def index
-    @interviews = Interview.where(user_id: current_user.id).order(interview_datetime: :asc)
+    @interviews = Interview.where(user_id: params[:user_id]).order(interview_datetime: :asc)
   end
 
   def new
@@ -38,7 +38,7 @@ class InterviewsController < ApplicationController
 
   private
   def create_params
-    params.require(:interview).permit(:interview_datetime).merge(user_id: current_user.id)
+    params.require(:interview).permit(:interview_datetime).merge(user_id: params[:user_id])
   end
 
   def update_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
   def index
+    @users = User.where.not(id: current_user.id)
   end
 
   def edit

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,9 @@
 class Interview < ApplicationRecord
   belongs_to :user
+
+  enum state: { pending: 0, approval: 1 }
+
+  def formated_datetime
+    self.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,13 @@ class User < ApplicationRecord
 
   enum sex: { male: 0, female: 1 }
   has_many :interview
+
+  def calc_birthday
+    if self.birthday != nil
+      (Date.today.strftime('%Y%m%d').to_i - self.birthday.strftime('%Y%m%d').to_i )/ 10000
+    else
+      ""
+    end
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   enum sex: { male: 0, female: 1 }
   has_many :interview
 
-  def calc_birthday
+  def calc_age
     if self.birthday != nil
       (Date.today.strftime('%Y%m%d').to_i - self.birthday.strftime('%Y%m%d').to_i )/ 10000
     else

--- a/app/views/interviews/_myInterview.html.haml
+++ b/app/views/interviews/_myInterview.html.haml
@@ -9,9 +9,9 @@
   - @interviews.each do |interview|
     %tr
       %td
-        = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+        = interview.formated_datetime
       %td
-        - if interview.state == 1
+        - if interview.approval?
           %p 承認
         - else
           %p 未確定

--- a/app/views/interviews/_myInterview.html.haml
+++ b/app/views/interviews/_myInterview.html.haml
@@ -3,12 +3,18 @@
 %table
   %thead
     %td 面接開始時間
+    %td 承認状態
     %td{ colspan: "2" } 日程編集
   %tbody
   - @interviews.each do |interview|
     %tr
       %td
         = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+      %td
+        - if interview.state == 1
+          %p 承認
+        - else
+          %p 未確定
       %td
         = link_to "編集", edit_user_interview_path(id: interview.id)
       %td

--- a/app/views/interviews/_myInterview.html.haml
+++ b/app/views/interviews/_myInterview.html.haml
@@ -1,0 +1,19 @@
+%h1 #{current_user.name}さんの面接一覧
+%p 新規日程作成より面接日程を登録しましょう。日程の変更、削除もできます。
+%table
+  %thead
+    %td 面接開始時間
+    %td{ colspan: "2" } 日程編集
+  %tbody
+  - @interviews.each do |interview|
+    %tr
+      %td
+        = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+      %td
+        = link_to "編集", edit_user_interview_path(id: interview.id)
+      %td
+        = link_to "削除", user_interview_path(id: interview.id), method: :DELETE
+
+%br
+= link_to "新規日程作成", new_user_interview_path
+= link_to "トップページ", users_path

--- a/app/views/interviews/_othersInterview.html.haml
+++ b/app/views/interviews/_othersInterview.html.haml
@@ -9,7 +9,7 @@
   - @interviews.each do |interview|
     %tr
       %td
-        = link_to interview.formated_datetime, user_interview_change_state_path(id: interview.id), method: "PATCH", data: {confirm: "#{interview.formated_datetime}で面接を確定します。よろしいですか？"}
+        = link_to interview.formated_datetime, user_interview_path(id: interview.id), method: "PATCH", data: {confirm: "#{interview.formated_datetime}で面接を確定します。よろしいですか？"}
       %td
         - if interview.approval?
           %p 面接が設定されています

--- a/app/views/interviews/_othersInterview.html.haml
+++ b/app/views/interviews/_othersInterview.html.haml
@@ -7,12 +7,11 @@
     %td 日程確定状態
   %tbody
   - @interviews.each do |interview|
-    - interview_date = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
     %tr
       %td
-        = link_to interview_date, user_interviews_change_state_path(id: interview.id), method: "POST", data: {confirm: "#{interview_date}で面接を確定します。よろしいですか？"}
+        = link_to interview.formated_datetime, user_interviews_change_state_path(id: interview.id), method: "POST", data: {confirm: "#{interview.formated_datetime}で面接を確定します。よろしいですか？"}
       %td
-        - if interview.state == 1
+        - if interview.approval?
           %p 面接が設定されています
 
 %br

--- a/app/views/interviews/_othersInterview.html.haml
+++ b/app/views/interviews/_othersInterview.html.haml
@@ -9,7 +9,7 @@
   - @interviews.each do |interview|
     %tr
       %td
-        = link_to interview.formated_datetime, user_interviews_change_state_path(id: interview.id), method: "POST", data: {confirm: "#{interview.formated_datetime}で面接を確定します。よろしいですか？"}
+        = link_to interview.formated_datetime, user_interview_change_state_path(id: interview.id), method: "PATCH", data: {confirm: "#{interview.formated_datetime}で面接を確定します。よろしいですか？"}
       %td
         - if interview.approval?
           %p 面接が設定されています

--- a/app/views/interviews/_othersInterview.html.haml
+++ b/app/views/interviews/_othersInterview.html.haml
@@ -1,16 +1,20 @@
-%h1 #{@interviews[0].user.name}さんの面接一覧
+%h1 #{@user.name}さんの面接一覧
 %h3 現在の面接日程
-
+%p 面接日程を確定する場合は以下から選んでください。
 %table
   %thead
     %td 面接開始時間
+    %td 日程確定状態
   %tbody
   - @interviews.each do |interview|
+    - interview_date = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
     %tr
       %td
-        = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+        = link_to interview_date, user_interviews_change_state_path(id: interview.id), method: "POST", data: {confirm: "#{interview_date}で面接を確定します。よろしいですか？"}
+      %td
+        - if interview.state == 1
+          %p 面接が設定されています
 
 %br
-= link_to "新規日程作成", new_user_interview_path
 = link_to "トップページ", users_path
 

--- a/app/views/interviews/_othersInterview.html.haml
+++ b/app/views/interviews/_othersInterview.html.haml
@@ -1,0 +1,16 @@
+%h1 #{@interviews[0].user.name}さんの面接一覧
+%h3 現在の面接日程
+
+%table
+  %thead
+    %td 面接開始時間
+  %tbody
+  - @interviews.each do |interview|
+    %tr
+      %td
+        = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
+
+%br
+= link_to "新規日程作成", new_user_interview_path
+= link_to "トップページ", users_path
+

--- a/app/views/interviews/index.html.haml
+++ b/app/views/interviews/index.html.haml
@@ -1,22 +1,4 @@
-
-%h1 #{current_user.name}さんの面接一覧
-%p 新規日程作成より面接日程を登録しましょう。日程の変更、削除もできます。
-%table
-  %thead
-    %td 面接開始時間
-    %td{ colspan: "2" } 日程編集
-  %tbody
-  - @interviews.each do |interview|
-    %tr
-      %td
-        = interview.interview_datetime.strftime("%Y/%m/%d  %H:%M:%S")
-      %td
-        = link_to "編集", edit_user_interview_path(id: interview.id)
-      %td
-        = link_to "削除", user_interview_path(id: interview.id), method: :DELETE
-
-
-%br
-= link_to "新規日程作成", new_user_interview_path
-= link_to "トップページ", users_path
-
+- if params[:user_id].to_i == current_user.id
+  = render partial: "myInterview"
+- else
+  = render partial: "othersInterview"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -17,7 +17,7 @@
       %td
         = user.email
       %td
-        = user.calc_birthday
+        = user.calc_age
       %td
         = user.sex
       %td

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -24,6 +24,6 @@
       %td
         = user.school_name
       %td
-        = link_to "面接一覧"
+        = link_to "面接一覧", user_interviews_path(user.id)
       %br
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,4 +1,29 @@
-%h1 ユーザー一覧が作られる予定の画面
+%h1 ユーザー一覧
 = link_to "ユーザー情報編集", edit_user_path(current_user.id)
 = link_to "面接日程一覧", user_interviews_path(current_user.id)
 = link_to "ログアウト", users_sign_out_path
+%table
+  %thead
+    %td 名前
+    %td e-mail
+    %td 年齢
+    %td 性別
+    %td 学校名
+    %td
+  - @users.each do |user|
+    %tr
+      %td
+        = user.name
+      %td
+        = user.email
+      %td
+        - if user.birthday != nil
+          = (Date.today.strftime('%Y%m%d').to_i - user.birthday.strftime('%Y%m%d').to_i )/ 10000
+      %td
+        = user.sex
+      %td
+        = user.school_name
+      %td
+        = link_to "面接一覧"
+      %br
+

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -17,8 +17,7 @@
       %td
         = user.email
       %td
-        - if user.birthday != nil
-          = (Date.today.strftime('%Y%m%d').to_i - user.birthday.strftime('%Y%m%d').to_i )/ 10000
+        = user.calc_birthday
       %td
         = user.sex
       %td

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
     resources :interviews
   end
 
-  patch 'users/:user_id/interview/:id', to: 'interviews#change_state', as: 'user_interview_change_state'
+  # patch 'users/:user_id/interview/:id', to: 'interviews#change_state', as: 'user_interview_change_state'
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
     resources :interviews
   end
 
-  post 'users/:user_id/interviews/:id', to: 'interviews#change_state', as: 'user_interviews_change_state'
+  patch 'users/:user_id/interview/:id', to: 'interviews#change_state', as: 'user_interview_change_state'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,9 @@ Rails.application.routes.draw do
     get '/users/sign_out' => 'devise/sessions#destroy'
   end
 
-  # resources :users, only: [:index, :edit, :update]
   resources :users, only: [:index, :edit, :update] do
     resources :interviews
   end
+
+  post 'users/:user_id/interviews/:id', to: 'interviews#change_state', as: 'user_interviews_change_state'
 end


### PR DESCRIPTION
やりたかったこと
---
- ユーザー一覧の表示
- 面接日程承認画面作成
- 面接日程承認のみ可能。却下は行わない。
- 画面のデザインはこだわってない

やったこと
----
- [x] user#indexで自分以外のユーザーを表示
- [x] ログイン中ユーザー以外で他idの面接一覧を表示すると日程承認画面を表示
- [x] 面接一覧画面で面接承認状態を確認可能とした
- [x] 面接承認用ルーティング、アクション追加

動作確認方法
---
- [ ] ユーザー1で面接日程を複数登録する
- [ ] ユーザー2でユーザー1の面接日程を確認し、承認する日程のリンクをクリックする。
- [ ] 承認前にalertが出るので、OKを押して承認する。
- [ ] ユーザー1で自分の面接日程を確認し、面接の承認状態を確認する。

その他
---
特筆なし